### PR TITLE
Add code for handling details of FileSystemOperation CreateFileMapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The PML format is very complex so there are some features (unchecked in the list
     - [ ] Filesystem Operations
         - [ ] VolumeDismount
         - [ ] VolumeMount
-        - [ ] CreateFileMapping
+        - [x] CreateFileMapping
         - [x] CreateFile
         - [ ] CreatePipe
         - [x] ReadFile

--- a/procmon_parser/consts.py
+++ b/procmon_parser/consts.py
@@ -1145,3 +1145,34 @@ FilesystemNotifyChangeFlags = OrderedDict([
 
 def get_filesysyem_notify_change_flags(flags):
     return _get_mask_string(flags, FilesystemNotifyChangeFlags, ", ")
+
+
+# Used for CreateFileMapping operation details (SyncType)
+FileSystemCreateFileMappingSyncType = OrderedDict([
+    (0x0, "SyncTypeOther"),
+    (0x1, "SyncTypeCreateSection"),
+    # 'Unknown' is everything else.
+])
+
+def get_filesystem_createfilemapping_synctype(synctype_value):
+    # type: (int) -> str
+    return FileSystemCreateFileMappingSyncType.get(synctype_value, "Unknown: {:#x}".format(synctype_value))
+
+
+class PAGE_PROTECTION(enum.IntFlag):
+    """Memory protection constants. Used for FilesystemOperation.CreateFileMapping event details.
+
+    See Also:
+        https://learn.microsoft.com/en-us/windows/win32/memory/memory-protection-constants
+    """
+    # PAGE_NOACCESS = 0x01 --> Not supported by CreateFileMapping, hence not used
+    PAGE_READ_ONLY = 0x02
+    PAGE_READWRITE = 0x04
+    PAGE_WRITECOPY = 0x08
+    PAGE_EXECUTE = 0x10
+    PAGE_EXECUTE_READ = 0x20
+    PAGE_EXECUTE_READWRITE = 0x40
+    PAGE_EXECUTE_WRITECOPY = 0x80
+    # PAGE_GUARD = 0x100  --> Not supported by CreateFileMapping, hence not used
+    PAGE_NOCACHE = 0x200
+    PAGE_WRITECOMBINE = 0x400 # seems to be not used by ProcMon, but is supported by CreateFileMapping

--- a/procmon_parser/consts.py
+++ b/procmon_parser/consts.py
@@ -1166,7 +1166,7 @@ class PAGE_PROTECTION(enum.IntFlag):
         https://learn.microsoft.com/en-us/windows/win32/memory/memory-protection-constants
     """
     # PAGE_NOACCESS = 0x01 --> Not supported by CreateFileMapping, hence not used
-    PAGE_READ_ONLY = 0x02
+    PAGE_READONLY = 0x02
     PAGE_READWRITE = 0x04
     PAGE_WRITECOPY = 0x08
     PAGE_EXECUTE = 0x10

--- a/procmon_parser/stream_logs_detail_format.py
+++ b/procmon_parser/stream_logs_detail_format.py
@@ -495,7 +495,9 @@ def get_filesystem_create_file_mapping(io, metadata, event, details_io, extra_de
     sync_type = read_u32(details_io)  # note: asm uses 'movsxd', so it's signed with sign extension.
     page_protection = read_u32(details_io)
     event.details["SyncType"] = get_filesystem_createfilemapping_synctype(sync_type)
-    event.details["PageProtection"] = str(PAGE_PROTECTION(page_protection))
+    page_protection_name = PAGE_PROTECTION(page_protection).name
+    if page_protection_name:
+        event.details["PageProtection"] = page_protection_name
 
 
 def get_filesystem_read_write_file_details(io, metadata, event, details_io, extra_detail_io):

--- a/tests/test_logs_format.py
+++ b/tests/test_logs_format.py
@@ -41,6 +41,7 @@ PARTIAL_SUPPORTED_COLUMNS = {
         "QueryRemoteProtocolInformation",
         "QueryIdInformation",
         "CreateFile",
+        "CreateFileMapping",
         "ReadFile",
         "WriteFile",
         "QueryDirectory",

--- a/tests/test_logs_format.py
+++ b/tests/test_logs_format.py
@@ -105,6 +105,11 @@ def are_we_better_than_procmon(pml_record, csv_record, column_name, pml_value, c
             if "QueryDirectory" == csv_record["Operation"]:
                 if csv_value in pml_value:
                     return True  # they don't write long directories sometimes
+            elif "CreateFileMapping" == csv_record["Operation"]:
+                if "PageProtection" in pml_value and "PageProtection" in csv_value:
+                    if pml_value[:pml_value.find("PageProtection")] == csv_value[:csv_value.find("PageProtection")]:
+                        # Procmon has a bug where they probably read the wrong struct field for PageProtection
+                        return True
     return False
 
 


### PR DESCRIPTION
A PR for FileSystemOperation CreateFileMapping. This PR is against commit f0b227389d88121c71e7e6b3e42f41bc85dc7760.

The details for the `CreateFileMapping` are basically the same as [`IRP_MJ_ACQUIRE_FOR_SECTION_SYNCHRONIZATION`](https://learn.microsoft.com/en-us/windows-hardware/drivers/ifs/flt-parameters-for-irp-mj-acquire-for-section-synchronization) but without `PFS_FILTER_SECTION_SYNC_OUTPUT ` (so, only `SyncType` and `PageProtection` are available, the remainder of the details in the PML file doesn't look like PFS_FILTER_SECTION_SYNC_OUTPUT is included at all).

![image](https://user-images.githubusercontent.com/4538670/220132111-854a1206-255f-4171-983e-2dda75f90ec1.png)


In ProcMon (3.92), you can easily find the function used for handling this operation by looking at X-refs to strings (such as `PAGE_EXECUTE` and `SyncTypeOther`):

```
.text:00000001400485E4 loc_1400485E4:
.text:00000001400485E4                 mov     dword ptr [rbp+57h+var_90], ebx
.text:00000001400485E7                 movzx   ecx, word ptr [rcx+0Ch]  ; see [0]; rcx = 0x13
.text:00000001400485EB                 lea     eax, [rcx-1]    ; switch 47 cases ; eax = 0x12
.text:00000001400485EE                 lea     r13, cs:140000000h
.text:00000001400485F5                 cmp     eax, 2Eh
.text:00000001400485F8                 ja      def_140048609   ; jumptable 0000000140048609 default case, cases 8-13,21,35,36,39,42-44
```

Here's what RCX is pointing to (at 0x1400485E7 above):
```
0:000> db @rcx
000001af`6011305a  f8 03 00 00 24 53 00 00-03 00 00 00 13 00 00 00  ....$S.......... ; process_idx (0x3f8); tid (0x5324); Event class (3 = File_System); Operation_val (0x13: FilesystemOperation.CreateFileMapping)
000001af`6011306a  51 c4 1d 00 30 00 00 00-00 00 00 00 f7 ad d6 0c  Q...0........... ; (SHORT: 0xc451) ? ; (SHORT: 0x1d) ? ; duration (QWORD: 0x30); date (QWORD: 0x1D93C9C0CD6ADF7)
000001af`6011307a  9c 3c d9 01 2a 01 00 00-25 00 00 00 65 00 00 00  .<..*...%...e... ; result (0x12a); stacktrace_depth (SHORT: 0x25); ? ; details_size (0x65); 
000001af`6011308a  00 00 00 00 8c 64 d2 13-05 f8 ff ff 04 28 d2 13  .....d.......(.. ; extra_details_size (0) 

; followed by stacktrace (stacktrace_depth * sizeof (PVOID)) = 0x25 * 8 = 0x128 (296)
; followed by details (details_size: 0x65)
```

Below is the code handling the `SyncType` (just the start):

```
.text:000000014004A6A7                                         ; DATA XREF: sub_140048490:jpt_140048609↓o
.text:000000014004A6A7                 movzx   eax, word ptr [r14+28h] ; 0x25
.text:000000014004A6AC                 lea     rsi, [r14+rax*8]  ; rsi = 000001af`60113182
.text:000000014004A6B0                 test    ebx, ebx          ; ebx = 0
.text:000000014004A6B2                 jz      loc_14004A752
```

and basically the event + its details (stack trace is skipped and shown as `?`):

```
0:000> db @r14 L0x200
000001af`6011305a  f8 03 00 00 24 53 00 00-03 00 00 00 13 00 00 00  ....$S..........
000001af`6011306a  51 c4 1d 00 30 00 00 00-00 00 00 00 f7 ad d6 0c  Q...0...........
000001af`6011307a  9c 3c d9 01 2a 01 00 00-25 00 00 00 65 00 00 00  .<..*...%...e...
000001af`6011308a  00 00 00 00 8c 64 d2 13-05 f8 ff ff 04 28 d2 13  .....d.......(..
000001af`6011309a  05 f8 ff ff e7 d7 ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ......??????????
000001af`601130aa  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`601130ba  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`601130ca  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`601130da  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`601130ea  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`601130fa  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`6011310a  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`6011311a  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`6011312a  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`6011313a  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`6011314a  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`6011315a  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`6011316a  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`6011317a  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`6011318a  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`6011319a  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`601131aa  ?? ?? ?? ?? ?? ?? ?? ??-?? ?? ?? ?? ?? ?? ?? ??  ????????????????
000001af`601131ba  ?? ?? ?? ?? ?? ?? 00 00-04 00 00 00 01 00 00 00  ??????..........  ; start of details
000001af`601131ca  10 00 00 00 d0 70 94 cc-07 81 ff ff 00 00 00 00  .....p..........
000001af`601131da  00 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00  ................
000001af`601131ea  00 00 00 00 00 00 00 00-00 00 00 00 1f 80 ff ff  ................
000001af`601131fa  43 3a 5c 57 69 6e 64 6f-77 73 5c 53 79 73 74 65  C:\Windows\Syste
000001af`6011320a  6d 33 32 5c 63 6f 6e 68-6f 73 74 2e 65 78 65 a9  m32\conhost.exe.
000001af`6011321a  85 
```

The code switching between the different `SyncType`s:

```
.text:000000014004A752 loc_14004A752:                          ; CODE XREF: sub_140048490+2222↑j
.text:000000014004A752                 movsxd  rdx, dword ptr [rsi+44h]; rsi = 0x0x000001af60113182 (+0x44 = 000001af`601131c6) ; rdx = 1
; note: since that header is 0x34, then +0x44 is +0x10 (0x44 - 034) from the start of the details. (this is correct).
.text:000000014004A756                 test    edx, edx
.text:000000014004A758                 jz      short loc_14004A7CE
.text:000000014004A75A                 cmp     edx, 1
.text:000000014004A75D                 jz      short loc_14004A7B3 ; take
; ...
.text:000000014004A7B3 loc_14004A7B3:                          ; CODE XREF: sub_140048490+22CD↑j
.text:000000014004A7B3                 lea     rdx, aSynctypecreate ; "SyncTypeCreateSection"
.text:000000014004A7BA                 mov     rcx, rdi
.text:000000014004A7BD                 call    sub_1400AC8D0
.text:000000014004A7C2                 lea     rax, aSynctype  ; "SyncType"
.text:000000014004A7C9                 jmp     loc_140049CCA
```

The code for the `PageProtection` details is around the same location.
