### PR TITLE
Doc Fixes

### DIFF
--- a/docs/PML Format.md
+++ b/docs/PML Format.md
@@ -8,36 +8,36 @@ The file starts with a header:
 
 **PML Header**
 
-| Offset | Data Type      | Size (bytes)  | Description                                             |
-| ------ | -------------- | ------------- | ------------------------------------------------------- |
-| 0x000  | char[4]        |   4           | Magic Signature - `'PML_'`.                             |
-| 0x004  | uint32         |   4           | Version of the PML file. `9` in the current version.    |
-| 0x008  | uint32         |   4           | System bitness: 1 if the system is 64 bit, 0 otherwise. |
-| 0x00C  | wchar_t[0x10]  |  16           | Name of the computer (that did the capture).            |
-| 0x02C  | wchar_t[0x104] |  260          | System root path (e.g. "C:\Windows").                   |
-| 0x234  | uint32         |    4          | Total number of events in the log file.                 |
-| 0x238  | uint64         |    8          |  ?  (seems to be unused)                                |
-| 0x240  | uint64         |    8          | File offset to the start of the events array.           |
-| 0x248  | uint64         |    8          | File offset to an array of offsets to all the events.   |
-| 0x250  | uint64         |    8          | File offset to the array of processes.                  |
-| 0x258  | uint64         |    8          | File offset to the array of strings.                    |
-| 0x260  | uint64         |    8          | File offset to the icons array.                         |
-| 0x268  | uint64         |    8          | [`SYSTEM_INFO`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info)`.lpMaximumApplicationAddress`): Maximum User Address |
-| 0x270  | uint32         |    4          | [`OSVERSIONINFOEXW`](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexw)`.dwOSVersionInfoSize`) sizeof(OSVERSIONINFOEXW).|
-| 0x274  | uint32         |    8          | `OSVERSIONINFOEXW.dwMajorVersion`: Major version number of the operating system.        |
-| 0x278  | uint32         |    8          | `OSVERSIONINFOEXW.dwMinorVersion`: Minor version number of the operating system.        |
-| 0x27C  | uint32         |    8          | `OSVERSIONINFOEXW.dwBuildNumber`: Build number of the operating system.                 |
-| 0x280  | uint32         |    8          | `OSVERSIONINFOEXW.dwPlatformId`: Operating system platform.                             |
-| 0x284  | wchar_t[0x100] |  256          | `OSVERSIONINFOEXW.szCSDVersion`: Indicates the latest Service Pack installed.           |
-| 0x384  | uint16         |    2          | `OSVERSIONINFOEXW.wServicePackMajor`:  Major version number of the latest Service Pack. |
-| 0x386  | uint16         |    2          | `OSVERSIONINFOEXW.wServicePackMinor`:  Minor version number of the latest Service Pack. |
-| 0x388  | uint16         |    2          | `OSVERSIONINFOEXW.wSuiteMask`: Bit mask that identifies the product suites available.   |
-| 0x38A  | uint8          |    1          | `OSVERSIONINFOEXW.wProductType`: Additional information about the system.               |
-| 0x38B  | uint8          |    1          | `OSVERSIONINFOEXW.wReserved`: Reserved for future use.                                  |
-| 0x38C  | uint32         |    8          | [`SYSTEM_INFO`](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info)`.dwNumberOfProcessors`) Number of logical processors. |
-| 0x390  | uint64         |    8          | [`MEMORYSTATUSEX`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex)`.ullTotalPhys`: Total physical memory (in bytes). |
-| 0x398  | uint64         |    8          | File offset to the start of the events array (again).                                  |
-| 0x3A0  | uint64         |    8          | File offset to hosts and ports arrays.                                                 |
+| Offset | Data Type      | Size (bytes) | Description                                                                                                                                                      |
+| ------ | -------------- |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0x000  | char[4]        | 4            | Magic Signature - `'PML_'`.                                                                                                                                      |
+| 0x004  | uint32         | 4            | Version of the PML file. `9` in the current version.                                                                                                             |
+| 0x008  | uint32         | 4            | System bitness: 1 if the system is 64 bit, 0 otherwise.                                                                                                          |
+| 0x00C  | wchar_t[0x10]  | 32           | Name of the computer (that did the capture).                                                                                                                     |
+| 0x02C  | wchar_t[0x104] | 512          | System root path (e.g. "C:\Windows").                                                                                                                            |
+| 0x234  | uint32         | 4            | Total number of events in the log file.                                                                                                                          |
+| 0x238  | uint64         | 8            | ?  (seems to be unused)                                                                                                                                          |
+| 0x240  | uint64         | 8            | File offset to the start of the events array.                                                                                                                    |
+| 0x248  | uint64         | 8            | File offset to an array of offsets to all the events.                                                                                                            |
+| 0x250  | uint64         | 8            | File offset to the array of processes.                                                                                                                           |
+| 0x258  | uint64         | 8            | File offset to the array of strings.                                                                                                                             |
+| 0x260  | uint64         | 8            | File offset to the icons array.                                                                                                                                  |
+| 0x268  | uint64         | 8            | [`SYSTEM_INFO`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info)`.lpMaximumApplicationAddress`: Maximum User Address     |
+| 0x270  | uint32         | 4            | [`OSVERSIONINFOEXW`](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexw)`.dwOSVersionInfoSize`: `sizeof(OSVERSIONINFOEXW)`       |
+| 0x274  | uint32         | 8            | `OSVERSIONINFOEXW.dwMajorVersion`: Major version number of the operating system.                                                                                 |
+| 0x278  | uint32         | 8            | `OSVERSIONINFOEXW.dwMinorVersion`: Minor version number of the operating system.                                                                                 |
+| 0x27C  | uint32         | 8            | `OSVERSIONINFOEXW.dwBuildNumber`: Build number of the operating system.                                                                                          |
+| 0x280  | uint32         | 8            | `OSVERSIONINFOEXW.dwPlatformId`: Operating system platform.                                                                                                      |
+| 0x284  | wchar_t[0x100] | 512          | `OSVERSIONINFOEXW.szCSDVersion`: Indicates the latest Service Pack installed.                                                                                    |
+| 0x384  | uint16         | 2            | `OSVERSIONINFOEXW.wServicePackMajor`:  Major version number of the latest Service Pack.                                                                          |
+| 0x386  | uint16         | 2            | `OSVERSIONINFOEXW.wServicePackMinor`:  Minor version number of the latest Service Pack.                                                                          |
+| 0x388  | uint16         | 2            | `OSVERSIONINFOEXW.wSuiteMask`: Bit mask that identifies the product suites available.                                                                            |
+| 0x38A  | uint8          | 1            | `OSVERSIONINFOEXW.wProductType`: Additional information about the system.                                                                                        |
+| 0x38B  | uint8          | 1            | `OSVERSIONINFOEXW.wReserved`: Reserved for future use.                                                                                                           |
+| 0x38C  | uint32         | 4            | [`SYSTEM_INFO`](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info)`.dwNumberOfProcessors`: Number of logical processors.  |
+| 0x390  | uint64         | 8            | [`MEMORYSTATUSEX`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex)`.ullTotalPhys`: Total physical memory (in bytes). |
+| 0x398  | uint64         | 8            | File offset to the start of the events array (again).                                                                                                            |
+| 0x3A0  | uint64         | 8            | File offset to hosts and ports arrays.                                                                                                                           |
 
 The header has file pointers to 5 important arrays:
 
@@ -73,32 +73,32 @@ The array of processes, which allows every event to have the process as an index
 
 A process is represented by:
 
-| Offset    | Data Type | Description                                                  |
-| --------- | --------- | ------------------------------------------------------------ |
+| Offset    | Data Type | Description                                                         |
+|-----------| --------- |---------------------------------------------------------------------|
 | 0x0       | Uint32    | The process index (for events to use as a reference to the process) |
-| 0x4       | Uint32    | Process id                                                   |
-| 0x8       | Uint32    | Parent process id                                            |
-| 0xC       | Uint32    | Unknown                                                      |
-| 0x10      | Uint64    | Authentication id                                            |
-| 0x18      | Uint32    | Session number                                               |
-| 0x1C      | Uint32    | Unknown                                                      |
-| 0x20      | FILETIME  | The startinig time of the process.                           |
-| 0x28      | FILETIME  | The ending time of the process.                              |
-| 0x30      | Uint32    | 1 if the process is virtualized, 0 otherwise.                |
-| 0x34      | Uint32    | 1 if this process is 64 bit, 0 if WOW64.                     |
-| 0x38      | Uint32    | Integrity - as a string index                                |
-| 0x3C      | Uint32    | the user - as a string index                                 |
-| 0x40      | Uint32    | the process name - as a string index                         |
-| 0x44      | Uint32    | the image path - as a string index                           |
-| 0x48      | Uint32    | the command line - as a string index                         |
-| 0x4C      | Uint32    | company of the executable - as a string index                |
-| 0x50      | Uint32    | version of the executable - as a string index                |
-| 0x54      | Uint32    | description of the executable - as a string index            |
-| 0x58      | Uint32    | Icon index small (0x10 pixels)                               |
-| 0x5C      | Uint32    | Icon index big (0x20 pixels)                                 |
-| 0x0x60    | PVoid     | Unknown                                                      |
-| 0x64/0x68 | Uint32    | number of modules in the process                             |
-| 0x68/0x6C | Module[]  | Array of the modules loaded in the process.                  |
+| 0x4       | Uint32    | Process id                                                          |
+| 0x8       | Uint32    | Parent process id                                                   |
+| 0xC       | Uint32    | Parent Process index.                                               |
+| 0x10      | Uint64    | Authentication id                                                   |
+| 0x18      | Uint32    | Session number                                                      |
+| 0x1C      | Uint32    | Unknown                                                             |
+| 0x20      | FILETIME  | The startinig time of the process.                                  |
+| 0x28      | FILETIME  | The ending time of the process.                                     |
+| 0x30      | Uint32    | 1 if the process is virtualized, 0 otherwise.                       |
+| 0x34      | Uint32    | 1 if this process is 64 bit, 0 if WOW64.                            |
+| 0x38      | Uint32    | Integrity - as a string index                                       |
+| 0x3C      | Uint32    | the user - as a string index                                        |
+| 0x40      | Uint32    | the process name - as a string index                                |
+| 0x44      | Uint32    | the image path - as a string index                                  |
+| 0x48      | Uint32    | the command line - as a string index                                |
+| 0x4C      | Uint32    | company of the executable - as a string index                       |
+| 0x50      | Uint32    | version of the executable - as a string index                       |
+| 0x54      | Uint32    | description of the executable - as a string index                   |
+| 0x58      | Uint32    | Icon index small (0x10 pixels)                                      |
+| 0x5C      | Uint32    | Icon index big (0x20 pixels)                                        |
+| 0x60      | PVoid     | Unknown                                                             |
+| 0x64/0x68 | Uint32    | number of modules in the process                                    |
+| 0x68/0x6C | Module[]  | Array of the modules loaded in the process.                         |
 
 A module is represented by:
 


### PR DESCRIPTION
* Fix various mistakes I made in the previous PR #22 (sorry about that...)
* fix a few typos.
* Field at offset 0x0C in the Process structure is the `ParentProcessIndex`.

Concerning this last point, below is the code for the struct to XML file (ProcMon64 v3.92):

```
.text:000000014003B023                 mov     edx, [r14+4]  ; process ID at offset + 4
.text:000000014003B027                 lea     rcx, [rbp+57h+arg_18]
.text:000000014003B02B                 call    sub_14006FA00
.text:000000014003B030                 nop
.text:000000014003B031                 mov     rcx, rax
.text:000000014003B034                 call    sub_1400AC930
.text:000000014003B039                 mov     r8, rax
.text:000000014003B03C                 lea     rdx, aProcessid ; "ProcessId"

...

.text:000000014003B05B                 mov     edx, [r14+8]  ; ParentProcessId at offset +8
.text:000000014003B05F                 lea     rcx, [rbp+57h+var_A0]
.text:000000014003B063                 call    sub_14006FA00
.text:000000014003B068                 nop
.text:000000014003B069                 mov     rcx, rax
.text:000000014003B06C                 call    sub_1400AC930
.text:000000014003B071                 mov     r8, rax
.text:000000014003B074                 lea     rdx, aParentprocessi ; "ParentProcessId"

...

.text:000000014003B093                 mov     edx, [r14+0Ch]  ; ParentProcessIndex at offset + 0x0C
.text:000000014003B097                 lea     rcx, [rbp+57h+var_98]
.text:000000014003B09B                 call    sub_14006FA00
.text:000000014003B0A0                 nop
.text:000000014003B0A1                 mov     rcx, rax
.text:000000014003B0A4                 call    sub_1400AC930
.text:000000014003B0A9                 mov     r8, rax
.text:000000014003B0AC                 lea     rdx, aParentprocessi_0 ; "ParentProcessIndex"

...
```

I couldn't find any use for the field at offset +0x60... It doesn't seem to be used at all. I might be mistaken though.